### PR TITLE
Fix: Add 'depthanything-small' option to --arch_name

### DIFF
--- a/tools/testers/infer.py
+++ b/tools/testers/infer.py
@@ -27,7 +27,7 @@ from safetensors.torch import load_file  # 导入 safetensors 库
 # Argument parser
 def argument_parser():
     parser = argparse.ArgumentParser(description="Run single-image depth/surface normal estimation.")
-    parser.add_argument("--arch_name", type=str, default="depthanything-large", choices=['depthanything-large', 'depthanything-base', 'midas'], help="Select a method for inference.")
+    parser.add_argument("--arch_name", type=str, default="depthanything-large", choices=['depthanything-large', 'depthanything-base', 'depthanything-small'], help="Select a method for inference.")
     parser.add_argument("--mode", type=str, default="disparity", choices=['rel_depth', 'metric_depth', 'disparity'], help="Select a method for inference.")
     parser.add_argument("--checkpoint", type=str, default="prs-eth/marigold-v1-0", help="Checkpoint path or hub name.")
     parser.add_argument("--output_dir", type=str, required=True, help="Output directory.")


### PR DESCRIPTION
Hello, thank you for your code!
I encountered an issue when trying to run the small-version model.

When executing:

```bash
source scripts/00_infer.sh
```
I got the following error:

```bash
usage: infer.py [-h] [--arch_name {depthanything-large,depthanything-base,midas}]
                [--mode {rel_depth,metric_depth,disparity}]
                [--checkpoint CHECKPOINT] --output_dir OUTPUT_DIR
                [--processing_res PROCESSING_RES] [--seed SEED]
infer.py: error: argument --arch_name: invalid choice: 'depthanything-small' (choose from 'depthanything-large', 'depthanything-base', 'midas')
```
It turns out that in infer.py, the --arch_name argument only accepts three choices:

```python
parser.add_argument("--arch_name", type=str, default="depthanything-large", choices=['depthanything-large', 'depthanything-base', 'midas'], help="Select a method for inference.")
```
Since "depthanything-small" was not included in the choices list, the script couldn't recognize it.

# 💡 Solution
I modified the line in infer.py:

```python
choices=['depthanything-large', 'depthanything-base', 'midas']
```
to
```python
choices=['depthanything-large', 'depthanything-base', 'depthanything-small', 'midas']
```
After making this change, everything worked fine! 🚀

```bash
INFO:root:GPU numbers: 1
INFO:dinov2:using MLP layer as FFN
0 OK
1 OK
2 OK
3 OK
```
